### PR TITLE
Agregar modal de datos para hash, estado y ciudad

### DIFF
--- a/blockchain/views/modaDatos.html
+++ b/blockchain/views/modaDatos.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Modal de Datos - EnvExpress</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="/blockchain/css/style.css" rel="stylesheet" />
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
+    <div class="container">
+      <a class="navbar-brand" href="/blockchain/index.html">ENVEXPRESS</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="/blockchain/views/registrar.html">Registrar envío</a></li>
+          <li class="nav-item"><a class="nav-link" href="/blockchain/views/actualizar.html">Actualización del estado</a></li>
+          <li class="nav-item"><a class="nav-link" href="/blockchain/views/verificar.html">Verificar envío</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <section class="main">
+    <div class="container text-center">
+      <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#datosModal">
+        Abrir Modal
+      </button>
+    </div>
+  </section>
+
+  <div class="modal fade" id="datosModal" tabindex="-1" aria-labelledby="datosModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="datosModalLabel">Datos de Envío</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body form-container">
+          <form>
+            <div class="mb-3">
+              <label for="hash" class="form-label">Hash</label>
+              <input type="text" class="form-control" id="hash" />
+            </div>
+            <div class="mb-3">
+              <label for="estado" class="form-label">Estado</label>
+              <input type="text" class="form-control" id="estado" />
+            </div>
+            <div class="mb-3">
+              <label for="ciudad" class="form-label">Ciudad Actual</label>
+              <input type="text" class="form-control" id="ciudad" />
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+          <button type="button" class="btn btn-primary">Guardar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Añade nueva página `modaDatos.html` con un modal Bootstrap que incluye campos Hash, Estado y Ciudad Actual reutilizando los estilos existentes.

## Testing
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f2475094832599077e87684139b6